### PR TITLE
Fix/add proper mitmdump binary to macos builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
                     gh release download --repo kun-codes/mitmproxy-nuitka-binaries --pattern "mitmdump-macos-${{ env.ARCHITECTURE }}*.zip" --dir .
                     unzip mitmdump-macos*.zip
                     cp mitmdump-macos*/mitmdump Koncentro/mitmdump
+                    chmod +x Koncentro/mitmdump
                     cd Koncentro
 
             -   name: Download latest version of mitmproxy (Windows)


### PR DESCRIPTION
- use nuitka compiled mitmdump binaries for macos as official mitmproxy binaries aren't available in portable mode for mitmproxy/mitmdymp
- mitmdump binaries are sourced from here: https://github.com/kun-codes/mitmproxy-nuitka-binaries