### PR TITLE
fix(TaskList): fix task names not being editable

### DIFF
--- a/src/prefabs/taskList.py
+++ b/src/prefabs/taskList.py
@@ -112,27 +112,6 @@ class TaskList(ListView):
         # Force a repaint to update the indicator
         self.viewport().update()
 
-    def edit(self, index, trigger, event):
-        """
-        Override the edit method to show lineedit which is pre-filled with the task name
-        """
-        if trigger == QAbstractItemView.DoubleClicked:
-            task_name = self.model().data(index, Qt.DisplayRole)
-
-            editor = LineEdit(self)
-            editor.setProperty("transparent", False)
-            editor.setText(task_name)
-            # editor.setFixedWidth(self.viewport().width() - self.editor_width_reduction)
-            editor.editingFinished.connect(lambda: self.commitData(editor))
-            editor.setCursorPosition(0)
-            editor.setObjectName("editor")
-            self.setIndexWidget(index, editor)
-            editor.setFocus()
-
-            self.current_editor = editor
-            return True
-        return super().edit(index, trigger, event)
-
     def resizeEvent(self, event):
         """
         Instead of just resizing editor using itemDelegate's updateEditorGeometry method, I am resizing the editor here
@@ -142,12 +121,6 @@ class TaskList(ListView):
         super().resizeEvent(event)
         if self.current_editor:
             self.current_editor.setFixedWidth(self.viewport().width() - self.editor_width_reduction)
-
-    def commitData(self, editor):
-        index = self.currentIndex()
-        self.model().setData(index, editor.text(), Qt.DisplayRole)
-        self.current_editor = None
-        self.setIndexWidget(index, None)
 
     def mousePressEvent(self, e):
         """

--- a/src/prefabs/taskListItemDelegate.py
+++ b/src/prefabs/taskListItemDelegate.py
@@ -1,7 +1,7 @@
 from loguru import logger
 from PySide6.QtCore import QModelIndex, QRect, Qt, Signal
 from PySide6.QtGui import QColor, QFontMetrics, QPainter
-from PySide6.QtWidgets import QListView, QStyledItemDelegate, QStyleOptionViewItem, QWidget
+from PySide6.QtWidgets import QListView, QStyledItemDelegate, QStyleOptionViewItem, QWidget, QApplication
 from qfluentwidgets import (
     FluentIcon,
     ListItemDelegate,
@@ -9,6 +9,7 @@ from qfluentwidgets import (
     ToolTipPosition,
     TransparentToggleToolButton,
     isDarkTheme,
+    LineEdit,
 )
 
 from models.task_list_model import TaskListModel
@@ -264,4 +265,22 @@ class TaskListItemDelegate(ListItemDelegate):
         if size.height() < min_height:
             size.setHeight(min_height)
         return size
+
+    def createEditor(self, parent: QWidget, option: QStyleOptionViewItem, index: QModelIndex) -> QWidget:
+        lineEdit = LineEdit(parent.parent())
+        lineEdit.setProperty("transparent", False)
+        lineEdit.setStyle(QApplication.style())
+        lineEdit.setText(option.text)
+        return lineEdit
+
+    def setEditorData(self, editor, index):
+        text = self.parent().model().data(index, Qt.ItemDataRole.DisplayRole)
+        editor.setText(text)
+
+    def setModelData(self, editor, model, index):
+        text = editor.text()
+        if text:
+            model.setData(index, text, Qt.ItemDataRole.DisplayRole)
+        # else:
+        #     model.setData(index, "", Qt.ItemDataRole.DisplayRole)
 


### PR DESCRIPTION
- "/[basepath]/Koncentro/src/prefabs/taskList.py", line 148, in commitData self.model().setData(index, editor.text(), Qt.DisplayRole) ^^^^^^^^^^^ AttributeError: 'PySide6.QtWidgets.QWidget' object has no attribute 'text' QAbstractItemView::closeEditor called with an editor that does not belong to this view

this error was happening when trying to save the name of the new task after editing it.

- solved the error by moving create editor logic and save new task name logic to `taskListItemDelegate.py`