### PR TITLE
fix(ci): remove test signing from Windows CI workflow

### DIFF
--- a/.github/workflows/reusable-build-app.yml
+++ b/.github/workflows/reusable-build-app.yml
@@ -206,28 +206,6 @@ jobs:
                     path: 'build\__main__.dist\'
                     include-hidden-files: 'true'
 
-            -   name: Sign artifact (Windows)
-                uses: signpath/github-action-submit-signing-request@v1
-                if: matrix.os == 'windows-latest' && inputs.deployment == false  # deployment is set to false for
-                # test builds and this step is for test signing
-                with:
-                    api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-                    organization-id: ${{ secrets.SIGNPATH_ORG_ID }}
-                    project-slug: 'Koncentro_'
-                    signing-policy-slug: 'test-signing'
-                    artifact-configuration-slug: 'compiled-files'
-                    github-artifact-id: ${{ steps.upload-unsigned-artifact-windows.outputs.artifact-id }}
-                    wait-for-completion: 'true'
-                    output-artifact-directory: 'build\signed-win-artifact\'
-
-            -   name: Upload signed artifacts Windows
-                if: matrix.os == 'windows-latest' && inputs.deployment == false
-                uses: actions/upload-artifact@v4
-                with:
-                    name: 'Windows_${{ env.ARCHITECTURE }}-build-test-signed'
-                    path: 'build\signed-win-artifact\'
-                    include-hidden-files: 'true'
-
             -   name: Upload artifacts Linux
                 if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-24.04-arm'
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-create-installer.yml
+++ b/.github/workflows/reusable-create-installer.yml
@@ -60,15 +60,7 @@ jobs:
                     elif [[ "${{ matrix.os }}" == "ubuntu-22.04" || "${{ matrix.os }}" == "ubuntu-24.04-arm" ]]; then
                         echo "artifact-name=Linux_${{ env.ARCHITECTURE }}-build" >> $GITHUB_OUTPUT
                     elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-                        if [[ "${{ inputs.deployment }}" == "true" ]]; then
-                            # for release build, artifacts would be signed using release-signing so 
-                            # downloading unsigned artifact
-                            echo "artifact-name=Windows_x86_64-build" >> $GITHUB_OUTPUT
-                        else
-                            # for test build, artifacts would be signed using test-signing so 
-                            # downloading artifact signed using test-signing
-                            echo "artifact-name=Windows_x86_64-build-test-signed" >> $GITHUB_OUTPUT
-                        fi
+                        echo "artifact-name=Windows_x86_64-build" >> $GITHUB_OUTPUT
                     fi
                 shell: bash
 
@@ -191,25 +183,25 @@ jobs:
 
             -   name: Release-sign installer (Windows)
                 uses: signpath/github-action-submit-signing-request@v1
-                if: matrix.os == 'windows-latest'
+                if: matrix.os == 'windows-latest' && inputs.deployment
                 with:
                     api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
                     organization-id: ${{ secrets.SIGNPATH_ORG_ID }}
                     project-slug: 'Koncentro_'
-                    signing-policy-slug: ${{ inputs.deployment && 'release-signing' || 'test-signing' }}
+                    signing-policy-slug: 'release-signing'
                     artifact-configuration-slug: 'installer-exe'
                     github-artifact-id: ${{ steps.upload-unsigned-artifact-windows.outputs.artifact-id }}
                     wait-for-completion: 'true'
                     output-artifact-directory: 'dist/Koncentro-${{ env.KONCENTRO_VERSION }}-Installer-signed.exe'
 
             -   name: Delete unsigned installer artifact (Windows)
-                if: matrix.os == 'windows-latest'
+                if: matrix.os == 'windows-latest' && inputs.deployment
                 uses: geekyeggo/delete-artifact@v5
                 with:
                     name: Koncentro-${{ env.KONCENTRO_VERSION }}-Windows-x86_64-Installer
 
             -   name: Upload Signed Installer (Windows)
-                if: matrix.os == 'windows-latest'
+                if: matrix.os == 'windows-latest' && inputs.deployment
                 uses: actions/upload-artifact@v4
                 with:
                     name: Koncentro-${{ env.KONCENTRO_VERSION }}-Windows-x86_64-Installer


### PR DESCRIPTION
- had to do to be within SignPath's fair use signing limit. Test signing also consumes monthly quota